### PR TITLE
Do not allow to add place for single member in group

### DIFF
--- a/app/assets/locales/app_en.arb
+++ b/app/assets/locales/app_en.arb
@@ -250,6 +250,8 @@
   "places_list_suggestion_library_text": "Library",
   "places_list_suggestion_local_park_text": "Local park",
   "places_list_delete_dialog_content_text": "Are you sure you want to delete this place? This action cannot be undone.",
+  "place_list_add_member_to_add_places_title": "Add members to set up geofence",
+  "place_list_add_member_to_add_places_subtitle": "At least one member needs to join your group to create geofence locations.",
 
   "add_new_place_title": "Add a new place",
   "add_new_place_suggestion_text": "Some suggestions...",

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -246,7 +246,7 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sqflite_darwin (0.0.4):
+  - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
   - Toast (4.1.1)
@@ -282,7 +282,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+  - sqflite (from `.symlinks/plugins/sqflite/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -381,8 +381,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  sqflite_darwin:
-    :path: ".symlinks/plugins/sqflite_darwin/darwin"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -428,7 +428,7 @@ SPEC CHECKSUMS:
   FirebaseStorage: 1bf8f80ac3bb02c72844b7350e95e10be7113ef0
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_background_service_ios: e30e0d3ee69e4cee66272d0c78eacd48c2e94aac
-  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
+  flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
   flutter_timezone: ffb07bdad3c6276af8dada0f11978d8a1f8a20bb
   fluttertoast: e9a18c7be5413da53898f660530c56f35edfba9c
   geocoding_ios: d7460f56e80e118d57678efe5c2cdc888739ff18
@@ -454,11 +454,11 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   Toast: 1f5ea13423a1e6674c4abdac5be53587ae481c4e
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 9bf7626a50066852dd21123c4db8e9fe30622485
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/app/lib/ui/flow/geofence/places/places_list_screen.dart
+++ b/app/lib/ui/flow/geofence/places/places_list_screen.dart
@@ -239,13 +239,14 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           SvgPicture.asset(
-            Assets.images.icSendMessage,
+            Assets.images.icGeofenceIcon,
             colorFilter: ColorFilter.mode(
               context.colorScheme.textPrimary,
               BlendMode.srcATop,
             ),
+            width: 80,
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: 16),
           Text(
             context.l10n.place_list_add_member_to_add_places_title,
             style: AppTextStyle.header3.copyWith(

--- a/app/lib/ui/flow/geofence/places/places_list_screen.dart
+++ b/app/lib/ui/flow/geofence/places/places_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:style/animation/on_tap_scale.dart';
+import 'package:style/button/primary_button.dart';
 import 'package:style/extenstions/context_extenstions.dart';
 import 'package:style/indicator/progress_indicator.dart';
 import 'package:style/text/app_text_dart.dart';
@@ -35,6 +36,7 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
     runPostFrame(() {
       notifier = ref.watch(placesListViewStateProvider.notifier);
       notifier.loadPlaces(widget.spaceId);
+      notifier.getSpaceMember(widget.spaceId);
     });
   }
 
@@ -44,6 +46,7 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
 
     _observeError();
     _observeShowDeletePlaceDialog();
+    _observeInviteScreenNavigation();
 
     return AppPage(title: context.l10n.places_list_title, body: _body(state));
   }
@@ -55,6 +58,17 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
       );
     }
 
+    if (state.spaceMember.length <= 1) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: _emptyViewWith0Member(context, state),
+      );
+    }
+
+    return _listView(state);
+  }
+
+  Widget _listView(PlacesListState state) {
     final placeLength = (state.places.isEmpty) ? 0 : state.places.length + 1;
     return SafeArea(
       child: Column(
@@ -218,6 +232,44 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
     );
   }
 
+  Widget _emptyViewWith0Member(
+      BuildContext context, PlacesListState state) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SvgPicture.asset(
+            Assets.images.icSendMessage,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.textPrimary,
+              BlendMode.srcATop,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            context.l10n.place_list_add_member_to_add_places_title,
+            style: AppTextStyle.header3.copyWith(
+              color: context.colorScheme.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            context.l10n.place_list_add_member_to_add_places_subtitle,
+            style: AppTextStyle.subtitle1.copyWith(
+              color: context.colorScheme.textDisabled,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          PrimaryButton(context.l10n.message_add_new_member_title,
+              progress: state.fetchingInviteCode, onPressed: () {
+            notifier.onAddNewMemberTap(widget.spaceId);
+          }),
+        ],
+      ),
+    );
+  }
+
   String _getPlacesIcon(String name) {
     if (name == 'Home') {
       return Assets.images.icPlacesHomeIcon;
@@ -264,6 +316,16 @@ class _PlacesViewState extends ConsumerState<PlacesListScreen> {
               final isNetworkOff = await checkInternetConnectivity();
               isNetworkOff ? _showSnackBar() : notifier.deletePlace();
             });
+      }
+    });
+  }
+
+  void _observeInviteScreenNavigation() {
+    ref.listen(
+        placesListViewStateProvider
+            .select((state) => state.spaceInvitationCode), (previous, next) {
+      if (next.isNotEmpty) {
+        AppRoute.inviteCode(code: next, spaceName: '').push(context);
       }
     });
   }

--- a/app/lib/ui/flow/geofence/places/places_list_view_model.dart
+++ b/app/lib/ui/flow/geofence/places/places_list_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:data/api/auth/auth_models.dart';
 import 'package:data/api/place/api_place.dart';
 import 'package:data/api/space/api_space_service.dart';
@@ -26,6 +28,7 @@ class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
   final PlaceService placeService;
   final SpaceService spaceService;
   final ApiSpaceService apiSpaceService;
+  late StreamSubscription<List<ApiSpaceMember>> _spaceMemberSubscription;
 
   PlacesListViewNotifier(
       currentUser, this.placeService, this.spaceService, this.apiSpaceService)
@@ -52,12 +55,15 @@ class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
 
   void getSpaceMember(String spaceId) {
     try {
-      apiSpaceService.getStreamSpaceMemberBySpaceId(spaceId).listen((member) {
+      _spaceMemberSubscription = apiSpaceService
+          .getStreamSpaceMemberBySpaceId(spaceId)
+          .listen((member) {
         if (mounted) {
           state = state.copyWith(spaceMember: member);
         }
       });
     } catch (error, stack) {
+      state = state.copyWith(error: error);
       logger.e('PlaceListViewNotifier: error while stream space info',
           error: error, stackTrace: stack);
     }
@@ -131,6 +137,12 @@ class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
         stackTrace: stack,
       );
     }
+  }
+
+  @override
+  void dispose() {
+    _spaceMemberSubscription.cancel();
+    super.dispose();
   }
 }
 

--- a/app/lib/ui/flow/geofence/places/places_list_view_model.dart
+++ b/app/lib/ui/flow/geofence/places/places_list_view_model.dart
@@ -1,7 +1,10 @@
 import 'package:data/api/auth/auth_models.dart';
 import 'package:data/api/place/api_place.dart';
+import 'package:data/api/space/api_space_service.dart';
+import 'package:data/api/space/space_models.dart';
 import 'package:data/log/logger.dart';
 import 'package:data/service/place_service.dart';
+import 'package:data/service/space_service.dart';
 import 'package:data/storage/app_preferences.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -14,13 +17,18 @@ final placesListViewStateProvider =
   return PlacesListViewNotifier(
     ref.read(currentUserPod),
     ref.read(placeServiceProvider),
+    ref.read(spaceServiceProvider),
+    ref.read(apiSpaceServiceProvider),
   );
 });
 
 class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
   final PlaceService placeService;
+  final SpaceService spaceService;
+  final ApiSpaceService apiSpaceService;
 
-  PlacesListViewNotifier(currentUser, this.placeService)
+  PlacesListViewNotifier(
+      currentUser, this.placeService, this.spaceService, this.apiSpaceService)
       : super(PlacesListState(currentUser: currentUser));
 
   void loadPlaces(String spaceId) async {
@@ -39,6 +47,19 @@ class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
         error: error,
         stackTrace: stack,
       );
+    }
+  }
+
+  void getSpaceMember(String spaceId) {
+    try {
+      apiSpaceService.getStreamSpaceMemberBySpaceId(spaceId).listen((member) {
+        if (mounted) {
+          state = state.copyWith(spaceMember: member);
+        }
+      });
+    } catch (error, stack) {
+      logger.e('PlaceListViewNotifier: error while stream space info',
+          error: error, stackTrace: stack);
     }
   }
 
@@ -92,6 +113,25 @@ class PlacesListViewNotifier extends StateNotifier<PlacesListState> {
       );
     }
   }
+
+  void onAddNewMemberTap(String spaceId) async {
+    try {
+      state = state.copyWith(fetchingInviteCode: true);
+      final code =
+      await spaceService.getInviteCode(spaceId);
+      state = state.copyWith(
+          spaceInvitationCode: code ?? '',
+          fetchingInviteCode: false,
+          error: null);
+    } catch (error, stack) {
+      state = state.copyWith(error: error);
+      logger.e(
+        'MessageViewNotifier: Error while getting invitation code',
+        error: error,
+        stackTrace: stack,
+      );
+    }
+  }
 }
 
 @freezed
@@ -99,12 +139,15 @@ class PlacesListState with _$PlacesListState {
   const factory PlacesListState({
     @Default(false) bool loading,
     @Default(false) bool deletingPlaces,
+    @Default(false) bool fetchingInviteCode,
+    @Default('') String spaceInvitationCode,
     String? spaceId,
     DateTime? showDeletePlaceDialog,
     ApiPlace? placesToDelete,
     ApiUser? currentUser,
     @Default([]) List<ApiPlace> places,
     @Default([]) List<String> suggestions,
+    @Default([]) List<ApiSpaceMember> spaceMember,
     Object? error,
   }) = _PlacesListState;
 }

--- a/app/lib/ui/flow/geofence/places/places_list_view_model.freezed.dart
+++ b/app/lib/ui/flow/geofence/places/places_list_view_model.freezed.dart
@@ -18,12 +18,15 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$PlacesListState {
   bool get loading => throw _privateConstructorUsedError;
   bool get deletingPlaces => throw _privateConstructorUsedError;
+  bool get fetchingInviteCode => throw _privateConstructorUsedError;
+  String get spaceInvitationCode => throw _privateConstructorUsedError;
   String? get spaceId => throw _privateConstructorUsedError;
   DateTime? get showDeletePlaceDialog => throw _privateConstructorUsedError;
   ApiPlace? get placesToDelete => throw _privateConstructorUsedError;
   ApiUser? get currentUser => throw _privateConstructorUsedError;
   List<ApiPlace> get places => throw _privateConstructorUsedError;
   List<String> get suggestions => throw _privateConstructorUsedError;
+  List<ApiSpaceMember> get spaceMember => throw _privateConstructorUsedError;
   Object? get error => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -40,12 +43,15 @@ abstract class $PlacesListStateCopyWith<$Res> {
   $Res call(
       {bool loading,
       bool deletingPlaces,
+      bool fetchingInviteCode,
+      String spaceInvitationCode,
       String? spaceId,
       DateTime? showDeletePlaceDialog,
       ApiPlace? placesToDelete,
       ApiUser? currentUser,
       List<ApiPlace> places,
       List<String> suggestions,
+      List<ApiSpaceMember> spaceMember,
       Object? error});
 
   $ApiPlaceCopyWith<$Res>? get placesToDelete;
@@ -67,12 +73,15 @@ class _$PlacesListStateCopyWithImpl<$Res, $Val extends PlacesListState>
   $Res call({
     Object? loading = null,
     Object? deletingPlaces = null,
+    Object? fetchingInviteCode = null,
+    Object? spaceInvitationCode = null,
     Object? spaceId = freezed,
     Object? showDeletePlaceDialog = freezed,
     Object? placesToDelete = freezed,
     Object? currentUser = freezed,
     Object? places = null,
     Object? suggestions = null,
+    Object? spaceMember = null,
     Object? error = freezed,
   }) {
     return _then(_value.copyWith(
@@ -84,6 +93,14 @@ class _$PlacesListStateCopyWithImpl<$Res, $Val extends PlacesListState>
           ? _value.deletingPlaces
           : deletingPlaces // ignore: cast_nullable_to_non_nullable
               as bool,
+      fetchingInviteCode: null == fetchingInviteCode
+          ? _value.fetchingInviteCode
+          : fetchingInviteCode // ignore: cast_nullable_to_non_nullable
+              as bool,
+      spaceInvitationCode: null == spaceInvitationCode
+          ? _value.spaceInvitationCode
+          : spaceInvitationCode // ignore: cast_nullable_to_non_nullable
+              as String,
       spaceId: freezed == spaceId
           ? _value.spaceId
           : spaceId // ignore: cast_nullable_to_non_nullable
@@ -108,6 +125,10 @@ class _$PlacesListStateCopyWithImpl<$Res, $Val extends PlacesListState>
           ? _value.suggestions
           : suggestions // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      spaceMember: null == spaceMember
+          ? _value.spaceMember
+          : spaceMember // ignore: cast_nullable_to_non_nullable
+              as List<ApiSpaceMember>,
       error: freezed == error ? _value.error : error,
     ) as $Val);
   }
@@ -148,12 +169,15 @@ abstract class _$$PlacesListStateImplCopyWith<$Res>
   $Res call(
       {bool loading,
       bool deletingPlaces,
+      bool fetchingInviteCode,
+      String spaceInvitationCode,
       String? spaceId,
       DateTime? showDeletePlaceDialog,
       ApiPlace? placesToDelete,
       ApiUser? currentUser,
       List<ApiPlace> places,
       List<String> suggestions,
+      List<ApiSpaceMember> spaceMember,
       Object? error});
 
   @override
@@ -175,12 +199,15 @@ class __$$PlacesListStateImplCopyWithImpl<$Res>
   $Res call({
     Object? loading = null,
     Object? deletingPlaces = null,
+    Object? fetchingInviteCode = null,
+    Object? spaceInvitationCode = null,
     Object? spaceId = freezed,
     Object? showDeletePlaceDialog = freezed,
     Object? placesToDelete = freezed,
     Object? currentUser = freezed,
     Object? places = null,
     Object? suggestions = null,
+    Object? spaceMember = null,
     Object? error = freezed,
   }) {
     return _then(_$PlacesListStateImpl(
@@ -192,6 +219,14 @@ class __$$PlacesListStateImplCopyWithImpl<$Res>
           ? _value.deletingPlaces
           : deletingPlaces // ignore: cast_nullable_to_non_nullable
               as bool,
+      fetchingInviteCode: null == fetchingInviteCode
+          ? _value.fetchingInviteCode
+          : fetchingInviteCode // ignore: cast_nullable_to_non_nullable
+              as bool,
+      spaceInvitationCode: null == spaceInvitationCode
+          ? _value.spaceInvitationCode
+          : spaceInvitationCode // ignore: cast_nullable_to_non_nullable
+              as String,
       spaceId: freezed == spaceId
           ? _value.spaceId
           : spaceId // ignore: cast_nullable_to_non_nullable
@@ -216,6 +251,10 @@ class __$$PlacesListStateImplCopyWithImpl<$Res>
           ? _value._suggestions
           : suggestions // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      spaceMember: null == spaceMember
+          ? _value._spaceMember
+          : spaceMember // ignore: cast_nullable_to_non_nullable
+              as List<ApiSpaceMember>,
       error: freezed == error ? _value.error : error,
     ));
   }
@@ -227,15 +266,19 @@ class _$PlacesListStateImpl implements _PlacesListState {
   const _$PlacesListStateImpl(
       {this.loading = false,
       this.deletingPlaces = false,
+      this.fetchingInviteCode = false,
+      this.spaceInvitationCode = '',
       this.spaceId,
       this.showDeletePlaceDialog,
       this.placesToDelete,
       this.currentUser,
       final List<ApiPlace> places = const [],
       final List<String> suggestions = const [],
+      final List<ApiSpaceMember> spaceMember = const [],
       this.error})
       : _places = places,
-        _suggestions = suggestions;
+        _suggestions = suggestions,
+        _spaceMember = spaceMember;
 
   @override
   @JsonKey()
@@ -243,6 +286,12 @@ class _$PlacesListStateImpl implements _PlacesListState {
   @override
   @JsonKey()
   final bool deletingPlaces;
+  @override
+  @JsonKey()
+  final bool fetchingInviteCode;
+  @override
+  @JsonKey()
+  final String spaceInvitationCode;
   @override
   final String? spaceId;
   @override
@@ -269,12 +318,21 @@ class _$PlacesListStateImpl implements _PlacesListState {
     return EqualUnmodifiableListView(_suggestions);
   }
 
+  final List<ApiSpaceMember> _spaceMember;
+  @override
+  @JsonKey()
+  List<ApiSpaceMember> get spaceMember {
+    if (_spaceMember is EqualUnmodifiableListView) return _spaceMember;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_spaceMember);
+  }
+
   @override
   final Object? error;
 
   @override
   String toString() {
-    return 'PlacesListState(loading: $loading, deletingPlaces: $deletingPlaces, spaceId: $spaceId, showDeletePlaceDialog: $showDeletePlaceDialog, placesToDelete: $placesToDelete, currentUser: $currentUser, places: $places, suggestions: $suggestions, error: $error)';
+    return 'PlacesListState(loading: $loading, deletingPlaces: $deletingPlaces, fetchingInviteCode: $fetchingInviteCode, spaceInvitationCode: $spaceInvitationCode, spaceId: $spaceId, showDeletePlaceDialog: $showDeletePlaceDialog, placesToDelete: $placesToDelete, currentUser: $currentUser, places: $places, suggestions: $suggestions, spaceMember: $spaceMember, error: $error)';
   }
 
   @override
@@ -285,6 +343,10 @@ class _$PlacesListStateImpl implements _PlacesListState {
             (identical(other.loading, loading) || other.loading == loading) &&
             (identical(other.deletingPlaces, deletingPlaces) ||
                 other.deletingPlaces == deletingPlaces) &&
+            (identical(other.fetchingInviteCode, fetchingInviteCode) ||
+                other.fetchingInviteCode == fetchingInviteCode) &&
+            (identical(other.spaceInvitationCode, spaceInvitationCode) ||
+                other.spaceInvitationCode == spaceInvitationCode) &&
             (identical(other.spaceId, spaceId) || other.spaceId == spaceId) &&
             (identical(other.showDeletePlaceDialog, showDeletePlaceDialog) ||
                 other.showDeletePlaceDialog == showDeletePlaceDialog) &&
@@ -295,6 +357,8 @@ class _$PlacesListStateImpl implements _PlacesListState {
             const DeepCollectionEquality().equals(other._places, _places) &&
             const DeepCollectionEquality()
                 .equals(other._suggestions, _suggestions) &&
+            const DeepCollectionEquality()
+                .equals(other._spaceMember, _spaceMember) &&
             const DeepCollectionEquality().equals(other.error, error));
   }
 
@@ -303,12 +367,15 @@ class _$PlacesListStateImpl implements _PlacesListState {
       runtimeType,
       loading,
       deletingPlaces,
+      fetchingInviteCode,
+      spaceInvitationCode,
       spaceId,
       showDeletePlaceDialog,
       placesToDelete,
       currentUser,
       const DeepCollectionEquality().hash(_places),
       const DeepCollectionEquality().hash(_suggestions),
+      const DeepCollectionEquality().hash(_spaceMember),
       const DeepCollectionEquality().hash(error));
 
   @JsonKey(ignore: true)
@@ -323,18 +390,25 @@ abstract class _PlacesListState implements PlacesListState {
   const factory _PlacesListState(
       {final bool loading,
       final bool deletingPlaces,
+      final bool fetchingInviteCode,
+      final String spaceInvitationCode,
       final String? spaceId,
       final DateTime? showDeletePlaceDialog,
       final ApiPlace? placesToDelete,
       final ApiUser? currentUser,
       final List<ApiPlace> places,
       final List<String> suggestions,
+      final List<ApiSpaceMember> spaceMember,
       final Object? error}) = _$PlacesListStateImpl;
 
   @override
   bool get loading;
   @override
   bool get deletingPlaces;
+  @override
+  bool get fetchingInviteCode;
+  @override
+  String get spaceInvitationCode;
   @override
   String? get spaceId;
   @override
@@ -347,6 +421,8 @@ abstract class _PlacesListState implements PlacesListState {
   List<ApiPlace> get places;
   @override
   List<String> get suggestions;
+  @override
+  List<ApiSpaceMember> get spaceMember;
   @override
   Object? get error;
   @override

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1168,18 +1168,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1224,18 +1224,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1700,10 +1700,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   time:
     dependency: transitive
     description:
@@ -1860,10 +1860,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:

--- a/data/lib/service/space_service.dart
+++ b/data/lib/service/space_service.dart
@@ -106,25 +106,6 @@ class SpaceService {
     });
   }
 
-  Future<SpaceInfo?> getCurrentSpaceInfo() async {
-    final currentSpace = await getCurrentSpace();
-    if (currentSpace == null) return null;
-    final members = await spaceService.getMembersBySpaceId(currentSpace.id);
-    return SpaceInfo(
-      space: currentSpace,
-      members: members
-          .map((member) async {
-            final user = await userService.getUser(member.user_id);
-            return user != null
-                ? ApiUserInfo(
-                    user: user, isLocationEnabled: member.location_enabled)
-                : null;
-          })
-          .whereType<ApiUserInfo>()
-          .toList(),
-    );
-  }
-
   Future<SpaceInfo?> getSpaceInfo(String spaceId) async {
     final space = await getSpace(spaceId);
     if (space == null) return null;
@@ -143,15 +124,6 @@ class SpaceService {
     );
   }
 
-  Future<ApiSpace?> getCurrentSpace() async {
-    final spaceId = currentSpaceId;
-    if (spaceId!.isEmpty) {
-      final userId = currentUser?.id ?? '';
-      final userSpaces = await getUserSpaces(userId);
-      return userSpaces.firstOrNull;
-    }
-    return getSpace(spaceId);
-  }
 
   Future<List<ApiSpace?>> getUserSpaces(String userId) async {
     final spaceMembers = await spaceService.getSpaceMemberByUserId(userId);


### PR DESCRIPTION
- [x] show empty view with add member in group button
- [x] on tap add member navigate to invite code screen
- [x] after returning back from invite code screen update UI if new member added
- [x] remove unwanted code from space service

![Simulator Screen Recording - iPhone 15 Pro - 2024-12-06 at 11 19 49](https://github.com/user-attachments/assets/8eb39386-108c-4743-a663-71b92ee90994)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added localization entries for geofencing functionality, clarifying member requirements for creating geofences.
  - Enhanced the Places List screen to display an empty view when there are no members, with an option to invite new members directly.

- **Bug Fixes**
  - Improved error handling for space member updates and invitation code fetching.

- **Chores**
  - Streamlined the SpaceService class by removing less utilized methods, focusing on essential functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->